### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: increase-if-necessary
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Documentation/**'
+          - '*.md'
+
+configuration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Configuration/**'
+          - 'ext_emconf.php'
+          - 'composer.json'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Tests/**'
+          - 'phpunit*.xml'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'composer.json'
+          - 'composer.lock'

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,10 +1,98 @@
 <?php
 
-$createConfig = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
+declare(strict_types=1);
 
-return $createConfig(<<<'EOF'
+$header = <<<'EOF'
     This file is part of the package netresearch/nr-scheduler.
 
     For the full copyright and license information, please read the
     LICENSE file that was distributed with this source code.
-    EOF, __DIR__ . '/..');
+    EOF;
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/..')
+    ->exclude(['.Build', '.build', 'config', 'node_modules', 'var'])
+    ->notPath('ext_emconf.php');
+
+$config = new PhpCsFixer\Config();
+$config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        // Base rulesets
+        '@Symfony'         => true,
+        '@PER-CS3x0'       => true,
+
+        // Strict typing
+        'declare_strict_types' => true,
+
+        // Spacing
+        'concat_space' => ['spacing' => 'one'],
+
+        // Docblocks
+        'phpdoc_to_comment'          => false,
+        'no_superfluous_phpdoc_tags' => false,
+        'phpdoc_separation'          => [
+            'groups' => [['author', 'license', 'link']],
+        ],
+
+        // Aliases
+        'no_alias_functions' => true,
+
+        // Alignment
+        'binary_operator_spaces' => [
+            'operators' => [
+                '='  => 'align_single_space_minimal',
+                '=>' => 'align_single_space_minimal',
+            ],
+        ],
+
+        // No Yoda
+        'yoda_style' => [
+            'equal'                => false,
+            'identical'            => false,
+            'less_and_greater'     => false,
+            'always_move_variable' => false,
+        ],
+
+        // Imports
+        'global_namespace_import' => [
+            'import_classes'   => true,
+            'import_constants' => true,
+            'import_functions' => true,
+        ],
+        'no_unused_imports' => true,
+        'ordered_imports'   => ['sort_algorithm' => 'alpha'],
+
+        // Function declarations
+        'function_declaration' => [
+            'closure_function_spacing' => 'one',
+            'closure_fn_spacing'       => 'one',
+        ],
+
+        // Modern syntax
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays', 'arguments', 'parameters'],
+        ],
+
+        // Whitespace
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+
+        // Style preferences
+        'single_line_throw' => false,
+        'self_accessor'     => false,
+
+        // Header
+        'header_comment' => [
+            'header'       => $header,
+            'comment_type' => 'comment',
+            'location'     => 'after_open',
+            'separate'     => 'both',
+        ],
+    ])
+    ->setFinder($finder);
+
+if (method_exists($config, 'setUnsupportedPhpVersionAllowed')) {
+    $config->setUnsupportedPhpVersionAllowed(true);
+}
+
+return $config;

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,98 +1,10 @@
 <?php
 
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines
- * Install @fabpot's great php-cs-fixer tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix
- *
- * For more information read:
- *  http://www.php-fig.org/psr/psr-2/
- *  http://cs.sensiolabs.org
- */
+$createConfig = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
 
-if (PHP_SAPI !== 'cli') {
-    die('This script supports command line usage only. Please check your command.');
-}
+return $createConfig(<<<'EOF'
+    This file is part of the package netresearch/nr-scheduler.
 
-$header = <<<EOF
-This file is part of the package netresearch/nr-scheduler.
-
-For the full copyright and license information, please read the
-LICENSE file that was distributed with this source code.
-EOF;
-
-return (new PhpCsFixer\Config())
-    ->setRiskyAllowed(true)
-    ->setRules([
-        '@PSR12'                          => true,
-        '@PER-CS2x0'                      => true,
-        '@Symfony'                        => true,
-
-        // Additional custom rules
-        'declare_strict_types'            => true,
-        'concat_space'                    => [
-            'spacing' => 'one',
-        ],
-        'header_comment'                  => [
-            'header'       => $header,
-            'comment_type' => 'PHPDoc',
-            'location'     => 'after_open',
-            'separate'     => 'both',
-        ],
-        'phpdoc_to_comment'               => false,
-        'phpdoc_no_alias_tag'             => false,
-        'phpdoc_annotation_without_dot'   => false,
-        'no_superfluous_phpdoc_tags'      => false,
-        'phpdoc_separation'               => [
-            'groups' => [
-                [
-                    'author',
-                    'license',
-                    'link',
-                ],
-            ],
-        ],
-        'no_alias_functions'              => true,
-        'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => true,
-        ],
-        'single_line_throw'               => false,
-        'self_accessor'                   => false,
-        'global_namespace_import'         => [
-            'import_classes'   => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ],
-        'function_declaration'            => [
-            'closure_function_spacing' => 'one',
-            'closure_fn_spacing'       => 'one',
-        ],
-        'binary_operator_spaces'          => [
-            'operators' => [
-                '='  => 'align_single_space_minimal',
-                '=>' => 'align_single_space_minimal',
-            ],
-        ],
-        'yoda_style'                      => [
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
-            'always_move_variable' => false,
-        ],
-    ])
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->exclude('.build')
-            ->exclude('config')
-            ->exclude('node_modules')
-            ->exclude('var')
-            // Exclude ext_emconf.php - TYPO3 does not want declare(strict_types=1) in this file
-            ->notName('ext_emconf.php')
-            ->in(__DIR__ . '/../')
-    );
+    For the full copyright and license information, please read the
+    LICENSE file that was distributed with this source code.
+    EOF, __DIR__ . '/..');

--- a/Build/fractor.php
+++ b/Build/fractor.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,10 +19,10 @@ return FractorConfiguration::configure()
             __DIR__ . '/../Configuration',
             __DIR__ . '/../Resources',
             __DIR__ . '/../ext_*',
-        ]
+        ],
     )
     ->withSets(
         [
             Typo3LevelSetList::UP_TO_TYPO3_12,
-        ]
+        ],
     );

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the

--- a/Classes/AbstractAdditionalFieldProvider.php
+++ b/Classes/AbstractAdditionalFieldProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -32,7 +32,8 @@ use TYPO3\CMS\Scheduler\Task\Enumeration\Action;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 abstract class AbstractAdditionalFieldProvider extends SchedulerAbstractAdditionalFieldProvider
 {
@@ -129,11 +130,11 @@ abstract class AbstractAdditionalFieldProvider extends SchedulerAbstractAddition
             $field = GeneralUtility::makeInstance(
                 $fieldClass,
                 $identifier,
-                $this->getLabel($key, $config['translationFile'])
+                $this->getLabel($key, $config['translationFile']),
             );
 
             $field->setValue(
-                $this->getFieldValue($key, $taskInfo, $task, $schedulerModule)
+                $this->getFieldValue($key, $taskInfo, $task, $schedulerModule),
             );
 
             $field->setDescription(
@@ -141,8 +142,8 @@ abstract class AbstractAdditionalFieldProvider extends SchedulerAbstractAddition
                     $key . '.description',
                     $config['translationFile'],
                     [],
-                    true
-                )
+                    true,
+                ),
             );
 
             if ($field instanceof SelectField) {
@@ -185,7 +186,7 @@ abstract class AbstractAdditionalFieldProvider extends SchedulerAbstractAddition
                 $validator = GeneralUtility::makeInstance(
                     $validatorClassName,
                     $value,
-                    $key
+                    $key,
                 );
 
                 if (!$validator->validate()) {

--- a/Classes/AbstractTask.php
+++ b/Classes/AbstractTask.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrScheduler;
 
+use function in_array;
+
 use Netresearch\NrScheduler\Traits\FlashMessageTrait;
 use Netresearch\NrScheduler\Traits\TranslationTrait;
 use TYPO3\CMS\Core\Core\Environment;
@@ -18,15 +20,14 @@ use TYPO3\CMS\Core\Mail\MailMessage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MailUtility;
 
-use function in_array;
-
 /**
  * Abstract scheduler task.
  *
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 abstract class AbstractTask extends \TYPO3\CMS\Scheduler\Task\AbstractTask
 {
@@ -111,17 +112,17 @@ abstract class AbstractTask extends \TYPO3\CMS\Scheduler\Task\AbstractTask
         try {
             $sentMails = $this->sendEmail(
                 $this->getReportingEmailsAsArray(),
-                $this->getReportingContent($message)
+                $this->getReportingContent($message),
             );
 
             if ($sentMails === false) {
                 throw new Exception(
-                    'The reporting could not be sent!'
+                    'The reporting could not be sent!',
                 );
             }
         } catch (\Exception $exception) {
             throw new Exception(
-                'The reporting could not be sent due to the mail api throws the following error: ' . $exception->getMessage()
+                'The reporting could not be sent due to the mail api throws the following error: ' . $exception->getMessage(),
             );
         }
     }

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -17,8 +17,7 @@ namespace Netresearch\NrScheduler;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
-class Exception extends \Exception
-{
-}
+class Exception extends \Exception {}

--- a/Classes/Fields/AbstractField.php
+++ b/Classes/Fields/AbstractField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -17,7 +17,8 @@ namespace Netresearch\NrScheduler\Fields;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 abstract class AbstractField
 {

--- a/Classes/Fields/CheckBoxField.php
+++ b/Classes/Fields/CheckBoxField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class CheckBoxField extends AbstractField
 {

--- a/Classes/Fields/MultiSelectField.php
+++ b/Classes/Fields/MultiSelectField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -11,17 +11,18 @@ declare(strict_types=1);
 
 namespace Netresearch\NrScheduler\Fields;
 
-use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
-
 use function in_array;
 use function is_array;
+
+use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 
 /**
  * MultiSelect field.
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class MultiSelectField extends SelectField
 {

--- a/Classes/Fields/PasswordField.php
+++ b/Classes/Fields/PasswordField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class PasswordField extends AbstractField
 {

--- a/Classes/Fields/SelectField.php
+++ b/Classes/Fields/SelectField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class SelectField extends AbstractField
 {

--- a/Classes/Fields/TextAreaField.php
+++ b/Classes/Fields/TextAreaField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class TextAreaField extends AbstractField
 {

--- a/Classes/Fields/TextField.php
+++ b/Classes/Fields/TextField.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class TextField extends AbstractField
 {

--- a/Classes/Traits/FlashMessageTrait.php
+++ b/Classes/Traits/FlashMessageTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -23,7 +23,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait FlashMessageTrait
 {
@@ -125,7 +126,7 @@ trait FlashMessageTrait
             FlashMessage::class,
             $message,
             $headline,
-            $severity
+            $severity,
         );
 
         if (PHP_SAPI === 'cli') {

--- a/Classes/Traits/TranslationTrait.php
+++ b/Classes/Traits/TranslationTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3\CMS\Core\Localization\LanguageService;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait TranslationTrait
 {
@@ -56,7 +57,7 @@ trait TranslationTrait
         }
 
         $translation = $this->getLanguageService()->sL(
-            $languageFile . ':' . $name
+            $languageFile . ':' . $name,
         );
 
         if ($translation === '') {

--- a/Classes/Validators/AbstractValidator.php
+++ b/Classes/Validators/AbstractValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-scheduler.
  *
  * For the full copyright and license information, please read the
@@ -17,7 +17,8 @@ namespace Netresearch\NrScheduler\Validators;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 abstract class AbstractValidator
 {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
         "ssch/typo3-rector": "^2.0 || ^3.0",
-        "a9f/typo3-fractor": "^0.5"
+        "a9f/typo3-fractor": "^0.5",
+        "netresearch/typo3-ci-workflows": "^1.0"
     },
     "extra": {
         "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -43,16 +43,15 @@
         "typo3/cms-scheduler": "^12.4 || ^14.0"
     },
     "require-dev": {
+        "a9f/typo3-fractor": "^0.5",
         "friendsofphp/php-cs-fixer": "^3.65",
-        "saschaegerer/phpstan-typo3": "^1.0 || v2.x-dev",
         "overtrue/phplint": "^9.5",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.0 || ^2.0",
-        "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
-        "ssch/typo3-rector": "^2.0 || ^3.0",
-        "a9f/typo3-fractor": "^0.5",
-        "netresearch/typo3-ci-workflows": "^1.0"
+        "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
+        "saschaegerer/phpstan-typo3": "^1.0",
+        "ssch/typo3-rector": "^2.0 || ^3.0"
     },
     "extra": {
         "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-declare(strict_types=1);
 $EM_CONF['nr_scheduler'] = [
     'title'          => 'Netresearch - TYPO3 scheduler',
     'description'    => 'Extends the TYPO3 scheduler extension with some functions.',


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates