### PR TITLE
fix(composer): constrain TYPO3 dependencies to ^12.4 only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,9 @@
         }
     },
     "require": {
-        "typo3/cms-core": "^12.4 || ^14.0",
-        "typo3/cms-fluid": "^12.4 || ^14.0",
-        "typo3/cms-scheduler": "^12.4 || ^14.0"
+        "typo3/cms-core": "^12.4",
+        "typo3/cms-fluid": "^12.4",
+        "typo3/cms-scheduler": "^12.4"
     },
     "require-dev": {
         "a9f/typo3-fractor": "^0.5",


### PR DESCRIPTION
## Summary

- The require constraints allowed `^12.4 || ^14.0`, so composer resolved to TYPO3 v14.2.0 for the singleton CI jobs (Code Style, Rector, License Audit, Composer Audit) that don't participate in the `typo3-versions` matrix.
- TYPO3 v14's composer post-install hook runs `asset:publish`, which fails with `A registered extension for the service "backend.routes" requires the service to be available` in this extension-only package — breaking `composer install` for all four jobs on main.
- `ext_emconf.php` declares compatibility with TYPO3 12.4 only and the reusable workflow is invoked with `typo3-versions: ["^12.4"]`, so the `|| ^14.0` constraint was aspirational and unverified. Removing it aligns composer.json with ext_emconf.php and the tested matrix.

## Root cause per job

All four failures share the same root cause — `composer install` picks v14.2.0 and the post-install `asset:publish` crashes, so no tool ever runs:

- `ci / Code Style` — composer install failed before php-cs-fixer could run
- `ci / Rector` — composer install failed before rector could run
- `license-check / PHP License Audit` — composer install failed before the license scanner could run
- `security / Composer Audit` — composer install failed before `composer audit` could run

## Test plan

- [x] `composer install` locally resolves `typo3/cms-core` to `v12.4.44` (was `v14.2.0`) and post-install `asset:publish` succeeds
- [x] `composer ci:test:php:cgl` — 0 of 15 files need fixing
- [x] `composer ci:test:php:rector` — `[OK] Rector is done!`
- [x] `composer audit` — `No security vulnerability advisories found.`
- [ ] CI on this PR is green