### PR TITLE
fix(deps): revert accidental TYPO3 v14 upgrade and pin majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: increase-if-necessary
+    # Block automatic TYPO3 framework major upgrades; extension is pinned to
+    # ^12.4 (see ext_emconf.php). Renovate has bypassed this in the past
+    # (PR #28 / PRs #34-36), so Dependabot must also enforce it as a backstop.
+    ignore:
+      - dependency-name: "typo3/cms-*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/composer.json
+++ b/composer.json
@@ -39,9 +39,9 @@
     },
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "^12.4 || ^14.0",
-        "typo3/cms-fluid": "^12.4 || ^14.0",
-        "typo3/cms-scheduler": "^12.4 || ^14.0"
+        "typo3/cms-core": "^12.4",
+        "typo3/cms-fluid": "^12.4",
+        "typo3/cms-scheduler": "^12.4"
     },
     "require-dev": {
         "a9f/typo3-fractor": "^0.5",

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,13 @@
   ],
   "automerge": true,
   "automergeType": "pr",
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^typo3/cms-"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+      "description": "Block automatic TYPO3 framework major upgrades; majors require manual scope review (extension is pinned to ^12.4, see ext_emconf.php). Pattern ^typo3/cms- also covers typo3/cms-composer-installers. See PR #28 / PRs #34-36 for prior incidents where Renovate bypassed the composer.json constraint."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Renovate merged PRs #34/#35/#36 on 2026-04-25 and bumped `typo3/cms-core`,
`typo3/cms-fluid` and `typo3/cms-scheduler` from `^12.4` to `^12.4 || ^14.0`
(commits d8e1308 / 5f350ee / 3fb938c). Composer then resolves to TYPO3 v14,
whose post-install `typo3 asset:publish` crashes with:

```
In ServiceProviderCompilationPass.php line 166:
  A registered extension for the service "backend.routes" requires the service
  to be available, which is missing.
```

This breaks every CI job on `main` — see run
[25656426964](https://github.com/netresearch/t3x-scheduler/actions/runs/25656426964).
The extension targets v12.4 only (`ext_emconf.php` declares
`'typo3' => '12.4.0-12.99.99'`) and has never been verified against v14.
This is the same pattern previously fixed in #28 (commit 1882017); Renovate
bypassed that constraint again.

## Changes

- **composer.json**: constrain `typo3/cms-core`, `typo3/cms-fluid`,
  `typo3/cms-scheduler` back to `^12.4` only — aligns with `ext_emconf.php` and
  the CI matrix (`typo3-versions: ["^12.4"]`).
- **renovate.json**: add a `packageRules` entry that disables `major` updates
  for `^typo3/cms-` (pattern also covers `typo3/cms-composer-installers`), so
  Renovate stops widening the constraint. The org-wide preset
  `github>netresearch/renovate-config` is extended *before* this rule, so the
  local override takes precedence.
- **.github/dependabot.yml**: add a matching `ignore` entry under the composer
  ecosystem for `typo3/cms-*` with
  `update-types: ["version-update:semver-major"]` as a backstop.

`ext_emconf.php` already declares `12.4.0-12.99.99` and needs no change.

## Test plan

- [x] `composer install` succeeds locally; resolves to `typo3/cms-core
  v12.4.45`; `typo3 asset:publish` no longer errors.
- [x] `composer ci:test` passes locally (phplint, phpstan, rector --dry-run,
  php-cs-fixer --dry-run) — exit code 0.
- [ ] CI green on `fix/revert-typo3-v14-and-lock-major`.

## Notes

- v14 support, if ever desired, should land in a dedicated change once the
  extension is actually verified against TYPO3 v14.
- No `version:` bumps in this PR — versioning is release-flow work.